### PR TITLE
feat: Add support for AMD/UMD modules.

### DIFF
--- a/src/crosstab.js
+++ b/src/crosstab.js
@@ -1,4 +1,4 @@
-var crosstab = (function () {
+;(function(define){define(function(require,exports,module){
 
     // --- Handle Support ---
     // See: http://detectmobilebrowsers.com/about
@@ -570,6 +570,9 @@ var crosstab = (function () {
         keepaliveLoop();
     }
 
-    return crosstab;
-})();
+    module.exports = crosstab;
 
+});})(typeof define=='function'&&define.amd?define
+:(function(n,w){'use strict';return typeof module=='object'?function(c){
+c(require,exports,module);}:function(c){var m={exports:{}};c(function(n){
+return w[n];},m.exports,m);w[n]=m.exports;};})('crosstab',this));


### PR DESCRIPTION
Uses the @wilsonpage super wrapper to provide support for AMD and UMD as well as provide access via a global `crosstab` variable if no module loader is used.

Wrapper can be found at https://gist.github.com/wilsonpage/8598603

fixes #3.
