### PR TITLE
fix bug on page reload

### DIFF
--- a/src/crosstab.js
+++ b/src/crosstab.js
@@ -275,6 +275,7 @@
 
         return {
             addListener: addListener,
+            destructor: destructor,
             on: addListener,
             off: function(event, key) {
                 var argsLen = arguments.length;


### PR DESCRIPTION
Uncaught TypeError: util.events.destructor is not a function