### PR TITLE
`beforeUnload` should stop `keepaliveLoop` from running

### DIFF
--- a/src/crosstab.js
+++ b/src/crosstab.js
@@ -370,6 +370,7 @@
     }
 
     function beforeUnload() {
+        crosstab.stopKeepalive = true;
         var numTabs = 0;
         util.forEach(util.tabs, function (tab, key) {
             if (key !== util.keys.MASTER_TAB) {

--- a/src/crosstab.js
+++ b/src/crosstab.js
@@ -369,7 +369,7 @@
         return item;
     }
 
-    function beforeUnload() {
+    function unload() {
         crosstab.stopKeepalive = true;
         var numTabs = 0;
         util.forEach(util.tabs, function (tab, key) {
@@ -686,7 +686,7 @@
     } else {
         // ---- Setup Storage Listener
         window.addEventListener('storage', onStorageEvent, false);
-        window.addEventListener('beforeunload', beforeUnload, false);
+        window.addEventListener('unload', unload, false);
 
         util.events.on('PING', function (message) {
             // only handle direct messages


### PR DESCRIPTION
Currently if we refresh the page right before the `keepaliveLoop` will trigger
(due to setTimeout), the tabs that were cleared by the `beforeUnload` method
will be restored by the `keepalive` method.

See the following screenshot of this bug happening in http://jsfiddle.net/8r6ueohf/5/
![screenshot 2015-06-18 01 34 58](https://cloud.githubusercontent.com/assets/456140/8227342/5b4e956e-155b-11e5-9e53-313401b62a08.png)

To reproduce the bug, just navigate to the jsfiddle link and keep refreshing until it happens. Basically the `setTimeout` will execute after the `beforeUnload` and the master tab will be set when it shouldn't.
The timing of refreshing is crucial for the problem to occur. Try with different timings (wait more or less before you refresh).

I got (after the refresh that triggered `Error: crosstab not supported: frozen tab environment detected`):
```
crosstab.util.tabs
> Object {14346168831240508221005: Object, MASTER_TAB: Object, 14346168852561009975541: Object}
crosstab.id
> "14346168852561009975541"
crosstab.util.tabs[crosstab.util.keys.MASTER_TAB]
> Object {id: "14346168831240508221005", lastUpdated: 1434616883124}
```

Locally I was able to reproduce easier with a `debugger` in `frozenTabEnvironmentDetected()` method.
That way I would see when that code would be called.
A few `console.log` in `setLocalStorageItem()` allowed me to see that `console.log(getLocalStorageItem(key));` would contain events `tabUpdated` and `tabPromoted` after the unloading of the tab.

Here are a couple of screenshots of what I saw during a refresh (aka `beforeUnload` + setup):
![screenshot 2015-06-18 00 01 05](https://cloud.githubusercontent.com/assets/456140/8227463/89d835c4-155c-11e5-8878-4b590902939b.png)

![screenshot 2015-06-18 00 01 21](https://cloud.githubusercontent.com/assets/456140/8227468/8f5b7dbc-155c-11e5-8047-1e5ccb7f73cb.png)

Notice the `preserve log` that has the content of the refresh + the info after the refresh (during setup). The `Navigated to ` info is what separates the before refresh and the actual (new) page load.
The only way to see this happening is with the `tabUpdated` event triggered by the `keepalive` on
```js
// broadcast tabUpdated event
broadcast(util.eventTypes.tabUpdated, myTab);`
```

It seems that beforeUnload occurs exactly at the same time as the setTimeout callback is added to the stack to be executed next, meaning that first it will execute:
```
util.tabs = {};
setStoredTabs();
```
and right after will trigger a set of events due to no master tab existence (`masterTabElection`, `setMaster` and `setStoredTabs`).