### PR TITLE
IE11 issues that seem to be unsolvable

### DIFF
--- a/src/crosstab.js
+++ b/src/crosstab.js
@@ -396,6 +396,18 @@
 
     }
 
+    function restoreLoop() {
+        crosstab.stopKeepalive = false;
+        keepaliveLoop();
+    }
+
+    function swapUnloadEvents() {
+        // `beforeunload` replaced by `unload` (IE11 will be smart now)
+        window.removeEventListener('beforeunload', unload, false);
+        window.addEventListener('unload', unload, false);
+        restoreLoop();
+    }
+
     function getMaster() {
         return util.tabs[util.keys.MASTER_TAB];
     }
@@ -705,7 +717,10 @@
     } else {
         // ---- Setup Storage Listener
         window.addEventListener('storage', onStorageEvent, false);
-        window.addEventListener('unload', unload, false);
+        // start with the `beforeunload` event due to IE11
+        window.addEventListener('beforeunload', unload, false);
+        // swap `beforeunload` to `unload` after DOM is loaded
+        window.addEventListener('DOMContentLoaded', swapUnloadEvents, false);
 
         util.events.on('PING', function (message) {
             // only handle direct messages


### PR DESCRIPTION
@tejacques, sorry to bother you again, but we just found the most weird/bizarre issue in IE...

With a piece of code as simple as this, running in the body/head (not on document ready):
http://jsfiddle.net/Ls3fbefj/1/

IE11 doesn't execute the unload function, only the `beforeunload` when refreshing while still loading (again hitting that sweet spot, since this doesn't happen all the time).
![](https://s3.amazonaws.com/uploads.hipchat.com/106041/1809298/6739yuTRsUpbQNF/upload.png)

See the highlighted part.

I'm not sure how this can be solved, since `beforeunload` is a cancelable event (like I explained in https://github.com/tejacques/crosstab/pull/31#issuecomment-113064771) we wouldn't be able to resume the `keepaliveLoop`.

Two things came to mind:

#### Solution 1:
The `crosstab` beforeunload function does what we are doing (canceling any `setTimeout` loop that might be executed at the end of the program stack) and at the bottom of the function we try to resume it in the next `TAB_TIMEOUT` like:
```js
// code that is in beforeunload

// try to resume after `TAB_KEEPALIVE` time if the tab is still alive...
window.setTimeout(function() {
    crosstab.stopKeepalive = false;
    keepaliveLoop();
}, TAB_KEEPALIVE);
```

I believe this solution will be problematic if the user takes `TAB_KEEPALIVE` time to say `yes` or `no` in the confirmation box of the example I posted in https://github.com/tejacques/crosstab/pull/31#issuecomment-113064771 and I'm not sure here if the code will execute or not (at least consistently against all modern browsers).

#### Solution 2:
We only start crosstab on document ready, wrapping the code near https://github.com/alias-mac/crosstab/blob/18ef65b8c471eb1bc5f634f73d700c3583f3af15/src/crosstab.js#L687:
```js
document.addEventListener("DOMContentLoaded", function(event) { 
  // ---- Setup Storage Listener
  // the rest of the code
});
```
We need to check if this would work normally on all browsers and if IE really executes the `unload` if the DOM is reported to be loaded (need to run some tests if you decide to go this way).

Most the browsers also support this on document ready:
http://caniuse.com/#search=DOMContentLoaded

There is still one problem with the frozen tabs even with any of the solutions posted above, when the browser crashes.
If the browser crashes, the localStorage is maintained in it's last state (unless you have IE11 again and some weird settings - see http://stackoverflow.com/questions/24489542/localstorage-resets-in-ie11-after-closing-browser).
In this event, how will we recover from frozen tab? Because we will try to ping the master tab that is gone (it was the window/tab that crashed).

Let me know which solution you think it is better or if we should drop frozen tab and find a different solution (like fallback to take over as the master tab and just resume everything - this will basically mean that if `crosstab` isn't supported, it will assume it is master all the time and broadcast to itself, right?).
