### PR TITLE
Use context variable rather than direct references to window/navigator

### DIFF
--- a/src/crosstab.js
+++ b/src/crosstab.js
@@ -4,18 +4,18 @@
  *
  * License: Apache 2.0 https://github.com/tejacques/crosstab/blob/master/LICENSE
  */
-; (function (define) { define('crosstab', function (require, exports, module) {
+; (function (root, define) { define('crosstab', function (require, exports, module) {
     'use strict';
 
     // --- Handle Support ---
     // See: http://detectmobilebrowsers.com/about
-    var useragent = navigator.userAgent || navigator.vendor || window.opera;
+    var useragent = (root.navigator ? (root.navigator.userAgent || root.navigator.vendor) : null) || root.opera || "none";
     var isMobile = (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od|ad)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(useragent) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(useragent.substr(0, 4)));
 
     var localStorage;
     try {
-        localStorage = window.localStorage;
-        localStorage = window['ie-eventlistener/storage'] || window.localStorage;
+        localStorage = root.localStorage;
+        localStorage = root['ie-eventlistener/storage'] || root.localStorage;
     } catch (e) {
         // New versions of Firefox throw a Security exception
         // if cookies are disabled. See
@@ -45,7 +45,7 @@
         if (!localStorage) {
             reasons.push('localStorage not availabe');
         }
-        if (!window.addEventListener) {
+        if (!root.addEventListener) {
             reasons.push('addEventListener not available');
         }
         if (isMobile) {
@@ -403,8 +403,8 @@
 
     function swapUnloadEvents() {
         // `beforeunload` replaced by `unload` (IE11 will be smart now)
-        window.removeEventListener('beforeunload', unload, false);
-        window.addEventListener('unload', unload, false);
+        root.removeEventListener('beforeunload', unload, false);
+        root.addEventListener('unload', unload, false);
         restoreLoop();
     }
 
@@ -575,7 +575,7 @@
     };
 
     crosstab.id = util.generateId();
-    crosstab.supported = !!localStorage && window.addEventListener && !isMobile && setItemAllowed;
+    crosstab.supported = !!localStorage && root.addEventListener && !isMobile && setItemAllowed;
     crosstab.util = util;
     crosstab.broadcast = broadcast;
     crosstab.broadcastMaster = broadcastMaster;
@@ -716,11 +716,11 @@
         crosstab.broadcast = notSupported;
     } else {
         // ---- Setup Storage Listener
-        window.addEventListener('storage', onStorageEvent, false);
+        root.addEventListener('storage', onStorageEvent, false);
         // start with the `beforeunload` event due to IE11
         window.addEventListener('beforeunload', unload, false);
         // swap `beforeunload` to `unload` after DOM is loaded
-        window.addEventListener('DOMContentLoaded', swapUnloadEvents, false);
+        root.addEventListener('DOMContentLoaded', swapUnloadEvents, false);
 
         util.events.on('PING', function (message) {
             // only handle direct messages
@@ -750,7 +750,7 @@
  *  2.) CommonJS
  *  3.) Context Variable (window in the browser)
  */
-});})(typeof define == 'function' && define.amd ? define
+});})(this, typeof define == 'function' && define.amd ? define
     : (function (context) {
         'use strict';
         return typeof module == 'object' ? function (name, factory) {

--- a/src/crosstab.js
+++ b/src/crosstab.js
@@ -4,18 +4,18 @@
  *
  * License: Apache 2.0 https://github.com/tejacques/crosstab/blob/master/LICENSE
  */
-; (function (root, define) { define('crosstab', function (require, exports, module) {
+; (function (window, define) { define('crosstab', function (require, exports, module) {
     'use strict';
 
     // --- Handle Support ---
     // See: http://detectmobilebrowsers.com/about
-    var useragent = (root.navigator ? (root.navigator.userAgent || root.navigator.vendor) : null) || root.opera || "none";
+    var useragent = (window.navigator ? (window.navigator.userAgent || window.navigator.vendor) : null) || window.opera || "none";
     var isMobile = (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od|ad)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(useragent) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(useragent.substr(0, 4)));
 
     var localStorage;
     try {
-        localStorage = root.localStorage;
-        localStorage = root['ie-eventlistener/storage'] || root.localStorage;
+        localStorage = window.localStorage;
+        localStorage = window['ie-eventlistener/storage'] || window.localStorage;
     } catch (e) {
         // New versions of Firefox throw a Security exception
         // if cookies are disabled. See
@@ -45,7 +45,7 @@
         if (!localStorage) {
             reasons.push('localStorage not availabe');
         }
-        if (!root.addEventListener) {
+        if (!window.addEventListener) {
             reasons.push('addEventListener not available');
         }
         if (isMobile) {
@@ -403,8 +403,8 @@
 
     function swapUnloadEvents() {
         // `beforeunload` replaced by `unload` (IE11 will be smart now)
-        root.removeEventListener('beforeunload', unload, false);
-        root.addEventListener('unload', unload, false);
+        window.removeEventListener('beforeunload', unload, false);
+        window.addEventListener('unload', unload, false);
         restoreLoop();
     }
 
@@ -575,7 +575,7 @@
     };
 
     crosstab.id = util.generateId();
-    crosstab.supported = !!localStorage && root.addEventListener && !isMobile && setItemAllowed;
+    crosstab.supported = !!localStorage && window.addEventListener && !isMobile && setItemAllowed;
     crosstab.util = util;
     crosstab.broadcast = broadcast;
     crosstab.broadcastMaster = broadcastMaster;
@@ -716,11 +716,11 @@
         crosstab.broadcast = notSupported;
     } else {
         // ---- Setup Storage Listener
-        root.addEventListener('storage', onStorageEvent, false);
+        window.addEventListener('storage', onStorageEvent, false);
         // start with the `beforeunload` event due to IE11
         window.addEventListener('beforeunload', unload, false);
         // swap `beforeunload` to `unload` after DOM is loaded
-        root.addEventListener('DOMContentLoaded', swapUnloadEvents, false);
+        window.addEventListener('DOMContentLoaded', swapUnloadEvents, false);
 
         util.events.on('PING', function (message) {
             // only handle direct messages


### PR DESCRIPTION
I'm running mocha tests in my app where I use crosstab. I run the mocha tests with the CLI without a browser, e.g. `mocha tests` where `tests` is the folder with all my tests in it.

Crosstab fails the tests due to it accessing `navigator` and `window` directly. It complains about `navigator` being `undefined`. If it could just get past this step, it wouldn't be a problem as I am using [sinon](http://sinonjs.org/) to mock the class that is using crosstab.

Anyway, I updated the UMD wrapper in crosstab to pass the current context (`this` - which will be `global` in node and `window` in the browser) down so that crosstab can get past that initial useragent check without blowing up when run from node.