### PR TITLE
Add crosstab.on('error', function(err){ }); support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,19 @@ var message = {
 ```
 
 The event will not fire if the destination is present and differs from the id of the current tab.
- 
+
+## Error Handling ##
+
+crosstab can asynchronously error when polling tabs to maintain internal state. To help you handle these errors, crosstab provides support for error handlers.
+
+```js
+crosstab.on('error', function(err){
+	/* handle error */
+});
+```
+
+If no error handler is provided errors will be thrown. If an error handler is provided errors caused by broadcast will be sent to the error handler rather than thrown.
+
 
 Why was it made?
 ----------------

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "es5-shim": "^4.1.12",
     "expect.js": "^0.3.1",
     "grunt": "~0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-connect": "~0.8.0",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-watch": "~0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crosstab",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "A utility library for cross-tab communication using localStorage.",
   "author": "Tom Jacques <tejacques@gmail.com>",
   "main": "src/crosstab.js",

--- a/src/crosstab.js
+++ b/src/crosstab.js
@@ -77,7 +77,15 @@
             errorMsg += ': ' + reasons.join(', ');
         }
 
-        throw new Error(errorMsg);
+        // Try to dispatch an error message
+        // and if there are no error message handlers
+        // throw it
+
+        var error = new Error(errorMsg);
+
+        if(!util.events.emit('error', error)){
+            throw error;
+        }
     }
 
     // --- Utility ---
@@ -289,6 +297,8 @@
                     listener.apply(this, args);
                 }
             });
+
+            return handlers.length > 0;
         };
 
         var once = function (event, listener, key) {
@@ -571,7 +581,7 @@
     // --- Setup message sending and handling ---
     function broadcast(event, data, destination) {
         if (!crosstab.supported) {
-            notSupported();
+            return notSupported();
         }
 
         var message = {

--- a/test/test-crosstab.js
+++ b/test/test-crosstab.js
@@ -232,6 +232,64 @@ describe('crosstab', function () {
         expect(received).to.be(undefined);
     });
 
+    it('should throw if not supported and no error listeners have been registered', function () {
+        crosstab.supported = false;
+        var sentMsg = null;
+        var throwError = null;
+
+        var throwHandler = crosstab.on('throw', function(msg){
+            sentMsg = msg;
+        });
+
+        try{
+            crosstab.broadcast('throw', 'msg');
+        }
+        catch(err){
+            throwError = err;
+        }
+
+        expect(sentMsg).to.be(null);
+        expect(typeof throwError).to.be('object');
+        expect(throwError.message).to.be('crosstab not supported');
+
+        crosstab.off('throw', throwHandler);
+
+        crosstab.supported = true;
+    });
+
+    it('should emit error if not supported and error listeners have been registered', function () {
+        crosstab.supported = false;
+        var sentMsg = null;
+        var thrownError = null;
+        var handledError = null;
+
+        var errorHandler = crosstab.on('error', function(err){
+            handledError = err;
+        });
+
+        var throwHandler = crosstab.on('emit', function(msg){
+            console.log('emit', msg);
+            sentMsg = msg;
+        });
+
+        try{
+            crosstab.broadcast('emit', 'msg');
+        }
+        catch(err){
+            thrownError = err;
+        }
+
+        expect(sentMsg).to.be(null);
+        expect(thrownError).to.be(null);
+        expect(typeof handledError).to.be('object');
+        expect(handledError.message).to.be('crosstab not supported');
+
+        crosstab.off('error', errorHandler);
+        crosstab.off('emit', throwHandler);
+
+        crosstab.supported = true;
+    });
+
     describe('with iframe', function () {
         this.timeout(1000);
         var iframe;


### PR DESCRIPTION
Currently crosstab is able to throw errors in a non catchable state via its internal polling. This PR implements support for an error handler.

If an error handler is supplied, all errors will be sent to the handlers. If no error handler is provided, the standard throw will happen.