### PR TITLE
fix: remove interval when destroying instance

### DIFF
--- a/src/crosstab.js
+++ b/src/crosstab.js
@@ -314,6 +314,7 @@
         };
 
         var destructor = function() {
+            clearInterval(crosstab.keepAliveInterval)
             removeAllListeners();
         };
 
@@ -799,7 +800,7 @@
             }
         });
 
-        setInterval(keepaliveLoop, TAB_KEEPALIVE);
+        crosstab.keepAliveInterval = setInterval(keepaliveLoop, TAB_KEEPALIVE);
         keepaliveLoop();
     }
 


### PR DESCRIPTION
Before this, the destructor method would still leave an interval timer hanging.
After this PR, the destructor method clears the interval.
This helps me by allowing me to use this module in tests without having them hang.
Please let me know if you'd like me to change anything.